### PR TITLE
Bump VCPKG

### DIFF
--- a/.github/workflows/_distribution.yml
+++ b/.github/workflows/_distribution.yml
@@ -23,7 +23,7 @@ jobs:
       ci_tools_version: v1.5-variegata
       extension_name: faiss
       vcpkg_url: "https://github.com/microsoft/vcpkg.git"
-      vcpkg_commit: 54760c3439fa2fdf2f42ccd730fcf2639c3fe101
+      vcpkg_commit: 26826180d398b4bb4f0453ae9d38a1c2c4d472dc
       # osx_amd64 is disabled due to a build faillure (should be fixable)
       exclude_archs: "wasm_mvp;wasm_eh;wasm_threads"
       build_duckdb_shell: false


### PR DESCRIPTION
In order to build with VS 18 (2026) we need a newer version of vcpkg